### PR TITLE
Update code for MiFit 2.0.0

### DIFF
--- a/db/miband.sql
+++ b/db/miband.sql
@@ -72,7 +72,7 @@ cast(RunDistanceMeter as text)||","||cast(RunTimeMin as text)||","||cast(RunBurn
 
 ||"]"||case when date = (select max(date) from date_data) then "" else "," end
  from (
-select id,date,
+select date,
 summary,
 cast(rtrim(substr(summary,instr(summary,'"lt":')+5,7),', "st":') as Integer) as LightSleepMin,
 cast(rtrim(substr(summary,instr(summary,'"dp":')+5,7),', "ed":') as Integer) as DeepSleepMin,
@@ -101,7 +101,7 @@ cast(rtrim(substr(summary,instr(summary,'"cal":')+6,4),', "runD') as Integer) as
 .output minmaxtime.csv
 
 with MyTable as (
-select id,datetime(date,'utc') as dt,
+select datetime(date,'utc') as dt,
 datetime(cast(rtrim(substr(summary,instr(summary,'"st":')+5,10),', "wk":') as Integer),'unixepoch','utc') as SleepStart,
 datetime(cast(rtrim(substr(summary,instr(summary,'"ed":')+5,10),', "v":') as Integer),'unixepoch','utc') as SleepEnd,
 cast(rtrim(substr(summary,instr(summary,'"rn":')+5,7),', "cal"') as Integer) as RunTimeMin,

--- a/run.sh
+++ b/run.sh
@@ -49,7 +49,8 @@ function fetch_db_root
 	fi
 	
 	echo $"adb copy $device temp data to sdcard" 2>&1 | tee -a log
-	./bin/adb shell "su -c 'cp /data/data/com.xiaomi.hm.health/databases/${data}* $SDPath/.'" 2>&1 | tee -a log
+	./bin/adb shell 'db=`su -c "ls /data/data/com.xiaomi.hm.health/databases/origin_db*(_+([0-9])) | tail -n 1"`; su -c "cp $db /sdcard/origin_db"' 2>&1 | tee -a log
+	./bin/adb shell 'db=`su -c "ls /data/data/com.xiaomi.hm.health/databases/origin_db*(_+([0-9]))-journal | tail -n 1"`; su -c "cp $db /sdcard/origin_db-journal"' 2>&1 | tee -a log
 	echo $"adb pull $device data from sdcard to local machine" >> log
 	./bin/adb pull $SDPath/${data} ./db/${data} 2>&1 | tee -a log
 	./bin/adb pull $SDPath/${data}-journal ./db/${data}-journal 2>&1 | tee -a log


### PR DESCRIPTION
Test device: Mi Band Pulse
# Problem

MiFit now stores data in multiple database with the file name
`origin_db_xxxx`. For example:

/data/data/com.xiaomi.hm.health/databases/origin_db
/data/data/com.xiaomi.hm.health/databases/origin_db-journal
/data/data/com.xiaomi.hm.health/databases/origin_db_329774917
/data/data/com.xiaomi.hm.health/databases/origin_db_329774917-journal
# Changes

This code will get the latest version of the database, as sorted by
filename, then copy them over to `/sdcard/origin_db` and
`/sdcard/origin_db-journal`

The new database table `DATE_DATA` no longer has the `id` field.
